### PR TITLE
Update file_length on save

### DIFF
--- a/dsp_save_parser/common.py
+++ b/dsp_save_parser/common.py
@@ -376,3 +376,22 @@ class SaveObject(ParserBase, metaclass=ABCMeta):
     #             # non typing types
     #             value = annotation(value)
     #     object.__setattr__(self, key, value)
+
+## DECORATORS ##
+# executed whenever a .save() call is made.
+# currently triggers a file_length write at a fixed location in the destination file
+def post_save(decorated):
+    def wrapper(*args, **kw):
+        output = decorated(*args, **kw)
+        # post-save actions
+        # 0.10.31: GameData.WarningSystem is the final object written to file.
+        # Overwrite file_length as final action.
+        if args[0].__class__.__name__ == "WarningSystem":
+            stream = args[1]
+            nf_length = uint32(stream.tell())
+            stream.seek(6)
+            stream.write(nf_length.to_bytes(4, _BYTE_ORDER))
+        #
+        return output
+    return wrapper
+##

--- a/dsp_save_parser/generator.py
+++ b/dsp_save_parser/generator.py
@@ -643,6 +643,7 @@ def write_py_class(class_def: dict, out_py_file: TextIO, line_no: int):
 
     # generate save method
     out_py_file.write('\n')
+    out_py_file.write('    @post_save\n')
     out_py_file.write('    def save(self, stream: BinaryIO):\n')
     # out_py_file.write('        assert stream.tell() == self.location_start\n')
     gen_pass_stub = True
@@ -816,7 +817,7 @@ def generate_parser(def_file: str, out_py_file: str):
                 return
     with open(out_py_file, 'w', encoding='utf8') as f:
         f.write('# Auto-generated file, do not edit\n\n')
-        f.write('from .common import *\nfrom typing import *\nfrom typing import BinaryIO\n\n')
+        f.write('from .common import *\nfrom .common import post_save\nfrom typing import *\nfrom typing import BinaryIO\n\n')
         with open(def_file, 'r', encoding='utf8') as f_def_fs:
             with StringIO(f_def_fs.read()) as f_def:
                 try:


### PR DESCRIPTION
When changing fields with dynamic size e.g. strings, file_length needs to be updated. This change forces a file_length update after saving.

This is implemented with a post_save decorator in common.py, with it being added to the save functions through the generator. I've tried to keep all DSP-specific logic out of generator.py.

It's fairly bruteforce compared to what the generator otherwise does in that it checks after any save function is called and determines whether it's the final object in the .dsv (in this DSP version the WarningSystem object is the final object saved), and it seeks to the specific file_length location directly for the write.

If this changes in future DSP versions it should be possible to update the logic in the decorator to accomodate.